### PR TITLE
Store commit data as hash and supply as parameter in challenge() and finalize()

### DIFF
--- a/contract/LibSubmarine.sol
+++ b/contract/LibSubmarine.sol
@@ -27,6 +27,7 @@ contract LibSubmarine is ProvethVerifier {
         uint256 _commitValue,
         bytes _commitData,
         bytes32 _witness,
+        bytes32 _commitBlockHash,
         uint32 _commitBlock,
         uint256 _commitIndex
     );
@@ -35,9 +36,9 @@ contract LibSubmarine is ProvethVerifier {
         uint8 _result,
         address indexed _sender,
         address indexed _submarine,
-        uint256 _slashAmount,
+        uint256 _slashAmount/*,
         bytes _proofBlob,
-        bytes _unsignedCommitTx
+        bytes _unsignedCommitTx*/ // Removed due to stack limit
     );
     event Finalized(
         bytes32 indexed _sessionId,
@@ -51,75 +52,93 @@ contract LibSubmarine is ProvethVerifier {
     // Storage //
     /////////////
 
-    uint256 public revealDepositAmount;   /* TODO: check if can be smaller than uint256 */
+    uint256 public revealDepositAmount;
     uint32 public challengePeriodLength;
     uint8 public vee = 27;
 
-    mapping(bytes32 => Session) public sessions;
-    mapping(uint32 => bytes32) public blockNumberToHash;
+    mapping(bytes32 => SessionData) public sessionData;
 
-    struct Session {
-        bool unlocked;       // set in unlock, used in reveal and finalize
-        address dappAddress; // set in reveal, used in finalize
-        uint256 commitValue; // set in reveal, used in unlock, challenge, and finalize
-        uint256 commitIndex; // set in reveal, used in challenge
-        uint32 commitBlock;  // set in reveal, used in challenge
-        uint32 revealBlock;  // set in reveal, used in unlock, challenge, and finalize
-        bytes commitData;    // set in reveal, used in finalize
+    struct SessionData {
+        bool unlocked;        // set in unlock, used in reveal and finalize
+        uint32 revealBlock;   // set in reveal, used in unlock, challenge, and finalize
+        uint256 commitValue;  // set in reveal, used in unlock, challenge, and finalize
+        bytes32 hashedCommit; // set in reveal, used in challenge, and finalize
     }
+
+    /* Layout of hashedCommit
+
+    bytes32 hashedCommit = keccak256(abi.encodePacked(
+        _commitBlockHash,
+        _commitBlock,
+        _commitIndex,
+        _dappAddress,
+        _commitData
+    ));
+
+    require(hashedCommit == sessionData[_sessionId].hashedCommit, "HashedCommit does not match sessionData");
+
+    struct HashedCommit {
+        bytes32 commitBlockHash // set in reveal, used in challenge
+        uint32 commitBlock;     // set in reveal, used in challenge
+        uint256 commitIndex;    // set in reveal, used in challenge
+        address dappAddress;    // set in reveal, used in finalize
+        bytes commitData;       // set in reveal, used in finalize
+    }
+    */
 
     /////////////
     // Getters //
     /////////////
 
     function getSessionId(
-        address _sender,
-        address _registry,
+        address _user,
+        address _libsubmarine,
         uint256 _commitValue,
         bytes _commitData,
         bytes32 _witness,
         uint256 _gasPrice,
         uint256 _gasLimit
     ) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(_sender, _registry, _commitValue, _commitData, _witness, _gasPrice, _gasLimit));
+        return keccak256(abi.encodePacked(_user, _libsubmarine, _commitValue, _commitData, _witness, _gasPrice, _gasLimit));
     }
 
     function getSession(bytes32 _sessionId) public view returns (
         bool unlocked,
-        uint256 commitValue,
-        uint256 commitIndex,
-        uint32 commitBlock,
         uint32 revealBlock,
-        bytes commitData,
-        address dappAddress
+        uint256 commitValue,
+        bytes32 hashedCommit
     ) {
-        Session memory sesh = sessions[_sessionId];
+        SessionData memory sesh = sessionData[_sessionId];
         return (
             sesh.unlocked,
-            sesh.commitValue,
-            sesh.commitIndex,
-            sesh.commitBlock,
             sesh.revealBlock,
-            sesh.commitData,
-            sesh.dappAddress
+            sesh.commitValue,
+            sesh.hashedCommit
         );
     }
 
-    /**
-     * @notice Checks if the session is ready to be finalized.
-     * @param _sessionId Hash of the session instance representing the commit/reveal transaction
-     */
-    function isFinalizable(bytes32 _sessionId) public view returns (bool finalized, uint256 commitValue, bytes commitData) {
-        if (block.number > sessions[_sessionId].revealBlock.add(challengePeriodLength)
-                    && sessions[_sessionId].unlocked
-                    && sessions[_sessionId].revealBlock > 0) {
-            return (
-                true,
-                sessions[_sessionId].commitValue,
-                sessions[_sessionId].commitData
-            );
-        }
-        return (false, 0, "");
+    function getBlockHash(uint32 _blockNumber) public view returns (bytes32 blockHash) {
+        blockHash = blockhash(_blockNumber);
+    }
+
+    function getHashedCommit(
+        bytes32 _commitBlockHash,
+        uint32 _commitBlock,
+        uint256 _commitIndex,
+        address _dappAddress,
+        bytes _commitData
+    ) public pure returns (bytes32 hashedCommit) {
+        hashedCommit = keccak256(abi.encodePacked(
+            _commitBlockHash,
+            _commitBlock,
+            _commitIndex,
+            _dappAddress,
+            _commitData
+        ));
+    }
+
+    function isFinalizable(bytes32 _sessionId) public view returns (bool) {
+        return (block.number > sessionData[_sessionId].revealBlock.add(challengePeriodLength) && sessionData[_sessionId].unlocked);
     }
 
     /////////////
@@ -131,8 +150,8 @@ contract LibSubmarine is ProvethVerifier {
      * @dev @warning Must be called within 256 blocks of the commit transaction to obtain the correct blockhash.
      * @param _commitBlock Block number in which the commit tx was created.
      * @param _commitIndex Index of the commit tx in the block.
-     * @param _dappAddress Address which can finalize the tx and retreive the funds.
      * @param _commitValue Value included in the commit tx.
+     * @param _dappAddress Address which can finalize the tx and retreive the funds.
      * @param _commitData Data to pass to the receiver dApp.
      * @param _witness Witness
      * @param _gasPrice Gas price
@@ -141,13 +160,15 @@ contract LibSubmarine is ProvethVerifier {
     function reveal(
         uint32 _commitBlock,
         uint256 _commitIndex,
-        address _dappAddress,
         uint256 _commitValue,
+        address _dappAddress,
         bytes _commitData,
         bytes32 _witness,
         uint256 _gasPrice,
         uint256 _gasLimit
     ) public payable {
+
+        bytes32 commitBlockHash = blockhash(_commitBlock);
         bytes32 sessionId = keccak256(abi.encodePacked(
             msg.sender,
             address(this),
@@ -156,34 +177,36 @@ contract LibSubmarine is ProvethVerifier {
             _witness,
             _gasPrice,
             _gasLimit
-        )); //implicitly checks msg.sender is A to generate valid sessionId
+        ));
+
         require(msg.value >= revealDepositAmount, "Reveal deposit not provided");
-        require(sessions[sessionId].revealBlock == 0, "The tx is already revealed");
-        require(!sessions[sessionId].unlocked, "The tx should not be already unlocked");
-        if (blockhash(_commitBlock) != 0x0) {
-            blockNumberToHash[_commitBlock] = blockhash(_commitBlock);
-        } // TODO we need to throw or do something to tell people when we can't find the block hash (too old)
-        sessions[sessionId].commitValue = _commitValue;
-        sessions[sessionId].commitIndex = _commitIndex;
-        sessions[sessionId].commitBlock = _commitBlock;
-        sessions[sessionId].revealBlock = uint32(block.number);
-        sessions[sessionId].commitData = _commitData;
-        sessions[sessionId].dappAddress = _dappAddress;
-        emit Revealed(sessionId, _commitValue, _commitData, _witness, _commitBlock, _commitIndex);
+        require(sessionData[sessionId].revealBlock == 0, "The tx is already revealed");
+        require(!sessionData[sessionId].unlocked, "The tx should not be already unlocked");
+        require(commitBlockHash != 0x0, "Commit Block is too old to retreive block hash (more than 256 blocks)");
+
+        sessionData[sessionId].revealBlock = uint32(block.number);
+        sessionData[sessionId].commitValue = _commitValue;
+        sessionData[sessionId].hashedCommit = keccak256(abi.encodePacked(
+            commitBlockHash,
+            _commitBlock,
+            _commitIndex,
+            _dappAddress,
+            _commitData
+        ));
+        emit Revealed(sessionId, _commitValue, _commitData, _witness, commitBlockHash, _commitBlock, _commitIndex);
     }
 
     /**
      * @notice Function called by the submarine address to unlock the session.
      * @param _sessionId Hash of the session instance representing the commit/reveal transaction
      */
-     // TODO: check if enum can be used for state transitions
     function unlock(bytes32 _sessionId) public payable {
-        require(sessions[_sessionId].revealBlock > 0
-            && !sessions[_sessionId].unlocked,
+        require(sessionData[_sessionId].revealBlock > 0
+            && !sessionData[_sessionId].unlocked,
             "The tx is already unlocked, or not yet revealed"
         );
-        require(msg.value == sessions[_sessionId].commitValue, "The unlocked value does not match the revealed value");
-        sessions[_sessionId].unlocked = true;
+        require(msg.value == sessionData[_sessionId].commitValue, "The unlocked value does not match the revealed value");
+        sessionData[_sessionId].unlocked = true;
         emit Unlocked(_sessionId, msg.value);
     }
 
@@ -220,12 +243,32 @@ contract LibSubmarine is ProvethVerifier {
      * @param _proofBlob proofBlob
      * @param _unsignedCommitTx unsignedCommitTx
      */
-    function challenge(bytes32 _sessionId, bytes _proofBlob, bytes _unsignedCommitTx) public {
-        require(block.number < sessions[_sessionId].revealBlock.add(challengePeriodLength), "Challenge period is not active");
-        require(sessions[_sessionId].revealBlock > 0, "Reveal tx has not yet been sent"); /* TODO: Check if need to require unlock has occured */
+    function challenge(
+        bytes32 _sessionId,
+        bytes _proofBlob,
+        bytes _unsignedCommitTx,
+        bytes32 _commitBlockHash,
+        uint32 _commitBlock,
+        uint256 _commitIndex,
+        address _dappAddress,
+        bytes _commitData
+    ) public {
+
+        SessionData memory sesh = sessionData[_sessionId];
+        bytes32 hashedCommit = keccak256(abi.encodePacked(
+            _commitBlockHash,
+            _commitBlock,
+            _commitIndex,
+            _dappAddress,
+            _commitData
+        ));
+
+        require(hashedCommit == sesh.hashedCommit, "HashedCommit does not match sessionData");
+        require(block.number < sesh.revealBlock.add(challengePeriodLength), "Challenge period is not active");
+        require(sesh.revealBlock > 0, "Reveal tx has not yet been sent"); /* TODO: Check if need to require unlock has occured */
 
         MPProof memory mpProof;
-        (mpProof.result, mpProof.index, mpProof.nonce, , , mpProof.to, mpProof.value, mpProof.data, , ,) = txProof(blockNumberToHash[sessions[_sessionId].commitBlock], _proofBlob);
+        (mpProof.result, mpProof.index, mpProof.nonce, , , mpProof.to, mpProof.value, mpProof.data, , ,) = txProof(_commitBlockHash, _proofBlob);
 
         // TX_PROOF_RESULT_INVALID = 0;
         // TX_PROOF_RESULT_PRESENT = 1;
@@ -236,12 +279,14 @@ contract LibSubmarine is ProvethVerifier {
         (,unsignedTx.sigHash , , , , , , ) = decodeAndHashUnsignedTx(_unsignedCommitTx);
 
         //ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) returns (address)
-        address submarine = ecrecover(
-            unsignedTx.sigHash,
-            vee,
-            keccak256(abi.encodePacked(_sessionId, byte(1))),
-            keccak256(abi.encodePacked(_sessionId, byte(0)))
-        );
+        // address submarine = ecrecover(
+        //     unsignedTx.sigHash,
+        //     vee,
+        //     keccak256(abi.encodePacked(_sessionId, byte(1))),
+        //     keccak256(abi.encodePacked(_sessionId, byte(0)))
+        // );
+
+        address submarine = extractAddress(unsignedTx.sigHash, _sessionId);
 
         /*
         The condition for slashing are as follows:
@@ -249,25 +294,34 @@ contract LibSubmarine is ProvethVerifier {
         2. Proof result == 1 -> commit tx is present, but falsified.
            One of the following condition must be true to prove the commit is falsified:
            - proof.to != address(submarine)
-           - proof.value <= sessions[_sessionId].commitValue
+           - proof.value <= sesh.commitValue
            - proof.data != 0x0
            - proof.nonce != 0
         */
-        if (mpProof.index == sessions[_sessionId].commitIndex
+        if (mpProof.index == _commitIndex
             && (mpProof.result == 2
                 || (mpProof.result == 1
                     && (keccak256(abi.encodePacked(mpProof.to)) != keccak256(abi.encodePacked(submarine))
-                        || mpProof.value <= sessions[_sessionId].commitValue
+                        || mpProof.value <= sesh.commitValue
                         || mpProof.data.length != 0
                         || mpProof.nonce != 0)))
         ) {
-            uint256 slashAmount = sessions[_sessionId].commitValue.add(revealDepositAmount);
+            uint256 slashAmount = sesh.commitValue.add(revealDepositAmount);
             msg.sender.transfer(slashAmount);
-            emit Slashed(_sessionId, mpProof.result, msg.sender, submarine, slashAmount, _proofBlob, _unsignedCommitTx);
-            delete sessions[_sessionId];
+            emit Slashed(_sessionId, mpProof.result, msg.sender, submarine, slashAmount/*, _proofBlob, _unsignedCommitTx */);
+            delete sessionData[_sessionId];
         } else {
             revert("Invalid Challenge");
         }
+    }
+
+    function extractAddress(bytes32 _sighash, bytes32 _sessionId) internal returns(address submarine) {
+        submarine = ecrecover(
+            _sighash,
+            vee,
+            keccak256(abi.encodePacked(_sessionId, byte(1))),
+            keccak256(abi.encodePacked(_sessionId, byte(0)))
+        );
     }
 
     /**
@@ -275,15 +329,37 @@ contract LibSubmarine is ProvethVerifier {
      * @dev The dDapp is responsible for refunding the reveal deposit to the user (TODO: add user address parameter)
      * @param _sessionId Hash of the session instance representing the commit/reveal transaction
      */
-    function finalize(bytes32 _sessionId) public returns (uint256 commitValue, bytes memory commitData) {
-        require(msg.sender == sessions[_sessionId].dappAddress, "The msg.sender does not match the dApp in the reveal tx");
-        require(block.number > sessions[_sessionId].revealBlock.add(challengePeriodLength)
-            && sessions[_sessionId].unlocked,
-            "The challenge period is not over, the tx was not unlocked, or the session was slashed");
-        commitValue = sessions[_sessionId].commitValue;
-        commitData = sessions[_sessionId].commitData;
-        sessions[_sessionId].dappAddress.transfer(commitValue.add(revealDepositAmount)); /* TODO: check if it is possible to return the deposit to the user directly */
+    function finalize(
+        bytes32 _sessionId,
+        bytes32 _commitBlockHash,
+        uint32 _commitBlock,
+        uint256 _commitIndex,
+        address _dappAddress,
+        bytes _commitData
+    ) public returns (
+        uint256 commitValue,
+        bytes memory commitData
+    ) {
+
+        SessionData memory sesh = sessionData[_sessionId];
+        bytes32 hashedCommit = keccak256(abi.encodePacked(
+            _commitBlockHash,
+            _commitBlock,
+            _commitIndex,
+            _dappAddress,
+            _commitData
+        ));
+
+        require(hashedCommit == sesh.hashedCommit, "HashedCommit does not match sessionData");
+        require(msg.sender == _dappAddress, "The msg.sender does not match the dApp in the reveal tx");
+        require(block.number > sesh.revealBlock.add(challengePeriodLength) && sesh.unlocked, "The challenge period is not over, the tx was not unlocked, or the session was slashed");
+
+        commitValue = sesh.commitValue;
+        commitData = _commitData;
+        _dappAddress.transfer(commitValue.add(revealDepositAmount)); /* TODO: check if it is possible to return the deposit to the user directly */
+
         emit Finalized(_sessionId, msg.sender, commitValue, revealDepositAmount, commitData);
-        delete sessions[_sessionId];
+
+        delete sessionData[_sessionId];
     }
 }

--- a/contract/LibSubmarine.sol
+++ b/contract/LibSubmarine.sol
@@ -9,22 +9,14 @@ contract LibSubmarine is ProvethVerifier {
     using SafeMath for uint256;
     using SafeMath32 for uint32;
 
-    uint256 public revealDepositAmount;   /* TODO: check if can be smaller than uint256 */
-    uint32 public challengePeriodLength;
-    uint8 public vee = 27;
-
-    mapping(bytes32 => Session) public sessions;
-    mapping(uint32 => bytes32) public blockNumberToHash;
-
-    struct Session {
-        bool unlocked;       // set in unlock, used in reveal and finalize
-        address dappAddress; // set in reveal, used in finalize
-        uint256 commitValue; // set in reveal, used in unlock, challenge, and finalize
-        uint256 commitIndex; // set in reveal, used in challenge
-        uint32 commitBlock;  // set in reveal, used in challenge
-        uint32 revealBlock;  // set in reveal, used in unlock, challenge, and finalize
-        bytes commitData;    // set in reveal, used in finalize
+    constructor(uint256 _revealDepositAmount, uint32 _challengePeriodLength) public {
+        revealDepositAmount = _revealDepositAmount;
+        challengePeriodLength = _challengePeriodLength;
     }
+
+    ////////////
+    // Events //
+    ////////////
 
     event Unlocked(
         bytes32 indexed _sessionId,
@@ -55,10 +47,25 @@ contract LibSubmarine is ProvethVerifier {
         bytes _commitData
     );
 
+    /////////////
+    // Storage //
+    /////////////
 
-    constructor(uint256 _revealDepositAmount, uint32 _challengePeriodLength) public {
-        revealDepositAmount = _revealDepositAmount;
-        challengePeriodLength = _challengePeriodLength;
+    uint256 public revealDepositAmount;   /* TODO: check if can be smaller than uint256 */
+    uint32 public challengePeriodLength;
+    uint8 public vee = 27;
+
+    mapping(bytes32 => Session) public sessions;
+    mapping(uint32 => bytes32) public blockNumberToHash;
+
+    struct Session {
+        bool unlocked;       // set in unlock, used in reveal and finalize
+        address dappAddress; // set in reveal, used in finalize
+        uint256 commitValue; // set in reveal, used in unlock, challenge, and finalize
+        uint256 commitIndex; // set in reveal, used in challenge
+        uint32 commitBlock;  // set in reveal, used in challenge
+        uint32 revealBlock;  // set in reveal, used in unlock, challenge, and finalize
+        bytes commitData;    // set in reveal, used in finalize
     }
 
     /////////////
@@ -114,6 +121,10 @@ contract LibSubmarine is ProvethVerifier {
         }
         return (false, 0, "");
     }
+
+    /////////////
+    // Setters //
+    /////////////
 
     /**
      * @notice Function called by the user to reveal the session.


### PR DESCRIPTION
Fix for #14 

Here is the gas consumption during the tests:
```
*** Gas Used ***
Commit:    21000
Reveal:    94673
Unlock:    32105
Finalize:  31500
Total:    179278
```